### PR TITLE
Rotate UI texture instead of `GUI.matrix` to fix misplaced/clipped icon draws

### DIFF
--- a/SmashTools/SmashTools/Rendering/Gui/RotatedTextureCache.cs
+++ b/SmashTools/SmashTools/Rendering/Gui/RotatedTextureCache.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Verse;
+using Object = UnityEngine.Object;
+
+namespace SmashTools.Rendering;
+
+/// <summary>
+/// Caches rotated copies of textures so a sprite can be drawn UN-rotated (which IMGUI's rectangular clipping handles
+/// correctly) while still appearing rotated. Rotating <see cref="GUI.matrix"/> instead would break clipping — it both
+/// mis-positions the draw and lets the GUI clip mask discard it.
+/// </summary>
+public static class RotatedTextureCache
+{
+  private static readonly Dictionary<(Texture, int), Texture2D> QuarterTurnCache = [];
+
+  private static readonly Dictionary<(Texture, int), Texture2D> ArbitraryCache = [];
+
+  /// <summary>
+  /// Rotated copy for a 90-degree step. Uses an exact pixel remap (no resampling), keeping the texture crisp.
+  /// </summary>
+  /// <param name="quarterTurns">Number of 90-degree steps (any integer; reduced mod 4).</param>
+  public static Texture2D GetRotated(Texture src, int quarterTurns)
+  {
+    quarterTurns = ((quarterTurns % 4) + 4) % 4;
+    if (src == null)
+      return null;
+    if (quarterTurns == 0)
+      return src as Texture2D;
+
+    (Texture, int) key = (src, quarterTurns);
+    if (QuarterTurnCache.TryGetValue(key, out Texture2D cached) && cached)
+      return cached;
+
+    Texture2D readable = AsReadable(src, out bool temporary);
+    if (readable == null)
+      return src as Texture2D;
+    Texture2D rotated = RotateQuarterTurns(readable, quarterTurns);
+    if (temporary)
+      Object.Destroy(readable);
+    QuarterTurnCache[key] = rotated;
+    return rotated;
+  }
+
+  /// <summary>
+  /// Rotated copy for an arbitrary angle (bilinear sampled into a diagonal-sized canvas so corners aren't clipped).
+  /// Matches <see cref="GetRotated"/> exactly at the cardinal angles. Cached to the nearest degree.
+  /// </summary>
+  public static Texture2D GetRotatedArbitrary(Texture src, float angle)
+  {
+    if (src == null)
+      return null;
+    int key = ((Mathf.RoundToInt(angle) % 360) + 360) % 360;
+    if (key == 0)
+      return src as Texture2D;
+
+    if (ArbitraryCache.TryGetValue((src, key), out Texture2D cached) && cached)
+      return cached;
+
+    Texture2D readable = AsReadable(src, out bool temporary);
+    if (readable == null)
+      return src as Texture2D;
+    Texture2D rotated = RotateArbitrary(readable, key);
+    if (temporary)
+      Object.Destroy(readable);
+    ArbitraryCache[(src, key)] = rotated;
+    return rotated;
+  }
+
+  /// <summary>
+  /// Returns a CPU-readable copy of <paramref name="src"/>, blitting through a <see cref="RenderTexture"/> when the
+  /// source isn't import-flagged readable (the common case for mod textures).
+  /// </summary>
+  private static Texture2D AsReadable(Texture src, out bool temporary)
+  {
+    temporary = false;
+    if (src is Texture2D { isReadable: true } direct)
+      return direct;
+    try
+    {
+      RenderTexture rt = RenderTexture.GetTemporary(src.width, src.height, 0, RenderTextureFormat.ARGB32);
+      RenderTexture previous = RenderTexture.active;
+      Graphics.Blit(src, rt);
+      RenderTexture.active = rt;
+      Texture2D readable = new(src.width, src.height, TextureFormat.RGBA32, false);
+      readable.ReadPixels(new Rect(0, 0, src.width, src.height), 0, 0);
+      readable.Apply();
+      RenderTexture.active = previous;
+      RenderTexture.ReleaseTemporary(rt);
+      temporary = true;
+      return readable;
+    }
+    catch (Exception ex)
+    {
+      Log.Warning($"[SmashTools] RotatedTextureCache GPU readback failed for '{src?.name}': {ex.Message}");
+      return null;
+    }
+  }
+
+  private static Texture2D RotateQuarterTurns(Texture2D src, int quarterTurns)
+  {
+    Color32[] pixels = src.GetPixels32();
+    int width = src.width;
+    int height = src.height;
+    bool swap = quarterTurns is 1 or 3;
+    int newWidth = swap ? height : width;
+    int newHeight = swap ? width : height;
+    Color32[] result = new Color32[pixels.Length];
+    for (int y = 0; y < height; y++)
+    {
+      for (int x = 0; x < width; x++)
+      {
+        Color32 color = pixels[y * width + x];
+        int nx;
+        int ny;
+        switch (quarterTurns)
+        {
+          case 1:
+            nx = y;
+            ny = width - 1 - x;
+            break;
+          case 2:
+            nx = width - 1 - x;
+            ny = height - 1 - y;
+            break;
+          case 3:
+            nx = height - 1 - y;
+            ny = x;
+            break;
+          default:
+            nx = x;
+            ny = y;
+            break;
+        }
+        result[ny * newWidth + nx] = color;
+      }
+    }
+    return BuildTexture(newWidth, newHeight, result, src.filterMode);
+  }
+
+  private static Texture2D RotateArbitrary(Texture2D src, float angle)
+  {
+    Color32[] pixels = src.GetPixels32();
+    int width = src.width;
+    int height = src.height;
+    // Diagonal canvas guarantees the rotated source always fits, for any angle.
+    int size = Mathf.CeilToInt(Mathf.Sqrt((float)width * width + (float)height * height));
+    Color32[] result = new Color32[size * size];
+
+    float radians = angle * Mathf.Deg2Rad;
+    float cos = Mathf.Cos(radians);
+    float sin = Mathf.Sin(radians);
+    float canvasCenter = size / 2f;
+    float centerX = width / 2f;
+    float centerY = height / 2f;
+
+    // For each destination pixel, sample the source at the inverse-rotated position. The sign matches the
+    // quarter-turn remap at the cardinal angles, so the two paths are seamless.
+    for (int ny = 0; ny < size; ny++)
+    {
+      for (int nx = 0; nx < size; nx++)
+      {
+        float dx = nx - canvasCenter;
+        float dy = ny - canvasCenter;
+        float sx = cos * dx - sin * dy + centerX;
+        float sy = sin * dx + cos * dy + centerY;
+        result[ny * size + nx] = SampleBilinear(pixels, width, height, sx, sy);
+      }
+    }
+    return BuildTexture(size, size, result, src.filterMode);
+  }
+
+  private static Color32 SampleBilinear(Color32[] pixels, int width, int height, float x, float y)
+  {
+    if (x < 0f || y < 0f || x > width - 1 || y > height - 1)
+      return new Color32(0, 0, 0, 0);
+
+    int x0 = (int)x;
+    int y0 = (int)y;
+    int x1 = Mathf.Min(x0 + 1, width - 1);
+    int y1 = Mathf.Min(y0 + 1, height - 1);
+    float fx = x - x0;
+    float fy = y - y0;
+
+    Color32 top = Color32.Lerp(pixels[y0 * width + x0], pixels[y0 * width + x1], fx);
+    Color32 bottom = Color32.Lerp(pixels[y1 * width + x0], pixels[y1 * width + x1], fx);
+    return Color32.Lerp(top, bottom, fy);
+  }
+
+  private static Texture2D BuildTexture(int width, int height, Color32[] pixels, FilterMode filterMode)
+  {
+    Texture2D texture = new(width, height, TextureFormat.RGBA32, false)
+    {
+      filterMode = filterMode,
+      wrapMode = TextureWrapMode.Clamp,
+    };
+    texture.SetPixels32(pixels);
+    texture.Apply();
+    return texture;
+  }
+}

--- a/SmashTools/SmashTools/UI/UIElements.cs
+++ b/SmashTools/SmashTools/UI/UIElements.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using RimWorld;
+using SmashTools.Rendering;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
@@ -581,20 +582,43 @@ public static class UIElements
 	public static void DrawTextureWithMaterialOnGUI(Rect rect, Texture texture,
 		Material material, float angle, Rect texCoords = default)
 	{
-		Matrix4x4 matrix = GUI.matrix;
-		try
+		angle = angle.ClampAngle();
+		if (Mathf.Approximately(angle, 0))
 		{
-			angle = angle.ClampAngle();
-			if (!Mathf.Approximately(angle, 0))
-			{
-				UI.RotateAroundPivot(angle, rect.center);
-			}
 			GenUI.DrawTextureWithMaterial(rect, texture, material, texCoords);
+			return;
 		}
-		finally
+
+		// Rotate the texture (and its mask) and draw it FLAT, rather than rotating GUI.matrix - which breaks IMGUI's
+		// rectangular clipping (it both mis-positions the sprite and lets the shader's clip mask discard it).
+		// 90-degree multiples use a fast exact pixel remap; other angles use a general bilinear rotation.
+		int quarterTurns = Mathf.RoundToInt(angle / 90f);
+		bool cardinal = Mathf.Abs(angle - quarterTurns * 90f) < 0.5f;
+
+		Texture rotatedTex = cardinal
+			? RotatedTextureCache.GetRotated(texture, quarterTurns)
+			: RotatedTextureCache.GetRotatedArbitrary(texture, angle);
+		Texture originalMask = material != null ? material.GetTexture("_MaskTex") : null;
+		Texture rotatedMask = originalMask == null ? null
+			: cardinal
+				? RotatedTextureCache.GetRotated(originalMask, quarterTurns)
+				: RotatedTextureCache.GetRotatedArbitrary(originalMask, angle);
+
+		// The general path renders into a larger (diagonal) canvas so corners aren't clipped; scale the draw rect to
+		// keep the sprite the same size, centered. The 90-degree path keeps the same size (scale 1).
+		Rect drawRect = rect;
+		if (rotatedTex != null && texture != null && texture.width > 0)
 		{
-			GUI.matrix = matrix;
+			float scale = (float)rotatedTex.width / texture.width;
+			if (scale > 1.001f)
+				drawRect = new Rect(Vector2.zero, rect.size * scale) { center = rect.center };
 		}
+
+		if (rotatedMask != null)
+			material.SetTexture("_MaskTex", rotatedMask);
+		GenUI.DrawTextureWithMaterial(drawRect, rotatedTex, material, texCoords);
+		if (rotatedMask != null)
+			material.SetTexture("_MaskTex", originalMask);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes the turret-positioning bug tracked in SmashPhil/Vehicle-Framework#260.

## Problem

`UIElements.DrawTextureWithMaterialOnGUI` rotates icons by rotating `GUI.matrix` (`UI.RotateAroundPivot`). For a materialed draw inside a GUI clip — e.g. side-facing vehicle turrets in the settings preview, build-menu gizmo, painter, caravan transfer widget — the sprite is both **mis-positioned** (flung off the body) and **clipped** (barrels cut at the panel edge, multi-turret vehicles dropping turrets). It only shows at non-1 UI scale, which is why it reads as a UI-scaling offset.

## Root cause

Rotating `GUI.matrix` is incompatible with IMGUI clipping, which assumes an axis-aligned frame. Three things break together the instant the matrix is tilted:

1. **The clip is disabled.** A rectangular scissor can't represent a rotated region, so Unity flips `GUIClip.enabled` to `false`. After that, `GUIClip.Unclip` / `GUIToScreenPoint` no longer agree with where pixels land — so any fix validated against them renders somewhere else.
2. **The pivot double-counts the clip offset.** `UI.RotateAroundPivot` pivots on `center * Prefs.UIScale` while the `GUIClip` origin is applied separately, so inside a nested clip the rotation flings the sprite (hence the UI-scale dependence).
3. **The shader clips again.** `ShaderRGBPatternUI` masks against Unity's `_GUIClipTexture` in the fragment stage and `clip()`s the rest. The rotated verts sample a mask still set for the un-rotated clip, so the pixels get discarded — the cut-off / missing turrets, not just a shift.

## Why the rotation itself can't be fixed

These are one bug, not three — position and clipping both fall out of that single rotation. Things I tried and why each fails:

- **correcting the pivot** (rotate about the matrix-output center) — `Unclip` confirms the center back on the body, but it still renders off, because (1) the disabled clip makes `Unclip` non-predictive and (3) the shader discards the rotated pixels regardless;
- **dropping the nested clip** — changes *where* it's clipped, not *whether*;
- **forcing `GUIClip.enabled` back on** — read-only, Unity owns it;
- **overriding `_GUIClipTexture`** with a white mask — Unity re-sets it per `Graphics.DrawTexture`, so it doesn't stick;
- **compositing inline through the GL `RenderTextureDrawer`** (which rotates correctly) — blanks the whole vehicle, since GL-into-a-RenderTexture can't run mid-`OnGUI`.

Net: any matrix that fixes the position still leaves the pixels getting discarded, and anything that escapes the discard leaves it misplaced. The only state that renders cleanly at any scale is an **un-rotated** draw.

## Fix

Rotate the **texture** (and its mask) and draw it flat, so the clip and shader operate on a normal axis-aligned quad — exactly as the vehicle body already does. 90° facings use an exact pixel remap (stays crisp); other angles a bilinear rotation into a diagonal-sized canvas (corners never clip), drawn at a proportionally-scaled rect so size and center are preserved — matching the 90° path exactly at the cardinal angles. Rotated copies are cached in `RotatedTextureCache`; the source textures aren't import-flagged readable, so it does a one-time `Blit` → `ReadPixels` to get a readable copy first.

## Notes

- Self-contained in SmashTools: new `Rendering/Gui/RotatedTextureCache.cs`, plus the change in `DrawTextureWithMaterialOnGUI` (the now-dead `GUI.matrix` save/restore is removed). No consumer changes.
- First use of a `(texture, angle)` pair does a GPU readback + CPU rotation; cached afterward, and only rotated draws pay it — unrotated draws are unchanged.