### PR TITLE
Make `RenderTextureDrawer.Draw` safe to run during OnGUI

### DIFF
--- a/SmashTools/SmashTools/Rendering/Gui/RenderTextureDrawer.cs
+++ b/SmashTools/SmashTools/Rendering/Gui/RenderTextureDrawer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using CoreLib;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -11,7 +11,14 @@ public static class RenderTextureDrawer
 {
   private static readonly List<RenderData> RenderDatas = [];
 
+  private static readonly int GuiClipTexId = Shader.PropertyToID("_GUIClipTexture");
+
+  private static Material defaultMaterial;
+
   private static RenderTexture renderTexture;
+
+  // Fallback material for render data without one; drawn unlit/transparent via raw GL.
+  private static Material DefaultMaterial => defaultMaterial ??= new Material(ShaderDatabase.MetaOverlay);
 
   public static bool InUse => renderTexture;
 
@@ -49,8 +56,20 @@ public static class RenderTextureDrawer
     }
     RenderDatas.Sort();
 
-    Assert.IsNull(RenderTexture.active);
+    // Save/restore the active target rather than asserting it is null, so a blit can run mid-OnGUI
+    // (where IMGUI owns the render target) without orphaning it.
+    RenderTexture prevActive = RenderTexture.active;
     RenderTexture.active = renderTexture;
+
+    // Graphics.DrawTexture honors GUI.matrix during OnGUI; neutralize it so RimWorld's UIScale
+    // doesn't compound with the GL transform below (which already fully positions each draw).
+    Matrix4x4 prevGuiMatrix = GUI.matrix;
+    GUI.matrix = Matrix4x4.identity;
+
+    // The UI shaders clip against the global _GUIClipTexture; when blitting inside a nested GUI clip
+    // (group/scroll view) that mask would crop the draw. Swap in a full-alpha mask to disable it.
+    Texture prevGuiClipTex = Shader.GetGlobalTexture(GuiClipTexId);
+    Shader.SetGlobalTexture(GuiClipTexId, Texture2D.whiteTexture);
 
     try
     {
@@ -69,13 +88,21 @@ public static class RenderTextureDrawer
       GL.PopMatrix();
       GL.Flush();
       RenderDatas.Clear();
-      RenderTexture.active = null;
+      RenderTexture.active = prevActive;
+      GUI.matrix = prevGuiMatrix;
+      Shader.SetGlobalTexture(GuiClipTexId, prevGuiClipTex);
+      // Reset the viewport off the texture size; otherwise GL.Viewport dedupes the next blit's
+      // identical call against this value and the blit inherits a stale (e.g. icon-sized) viewport.
+      GL.Viewport(new Rect(0, 0, Screen.width, Screen.height));
     }
     return;
 
     static void DrawRenderData(Rect rect, in RenderData renderData, float scale, bool center)
     {
-      if (renderData.material && !renderData.material.SetPass(0))
+      Material material = renderData.material ? renderData.material : DefaultMaterial;
+      if (renderData.mainTex)
+        material.mainTexture = renderData.mainTex;
+      if (!material.SetPass(0))
         return;
 
       GL.PushMatrix();
@@ -90,7 +117,19 @@ public static class RenderTextureDrawer
           * Matrix4x4.Translate(new Vector3(-0.5f, -0.5f, 0f));
         GL.MultMatrix(matrix);
 
-        Graphics.DrawTexture(new Rect(0, 0, 1, 1), renderData.mainTex, renderData.material);
+        // Raw GL quad rather than Graphics.DrawTexture: the latter is IMGUI-aware and re-applies the
+        // surrounding GUI clip's viewport mid-blit, cropping the draw inside nested groups / scroll views.
+        GL.Begin(GL.QUADS);
+        GL.Color(Color.white);
+        GL.TexCoord2(0f, 1f);
+        GL.Vertex3(0f, 0f, 0f);
+        GL.TexCoord2(1f, 1f);
+        GL.Vertex3(1f, 0f, 0f);
+        GL.TexCoord2(1f, 0f);
+        GL.Vertex3(1f, 1f, 0f);
+        GL.TexCoord2(0f, 0f);
+        GL.Vertex3(0f, 1f, 0f);
+        GL.End();
       }
       finally
       {
@@ -103,9 +142,11 @@ public static class RenderTextureDrawer
         float scaleX = renderTexture.width / rect.width;
         float scaleY = renderTexture.height / rect.height;
 
+        // Render data rects are in the outer rect's (absolute) coordinate space; rebase to the rect
+        // origin before scaling into RT-pixel space, otherwise the draw lands outside the texture.
         return new Rect(
-          input.x * scaleX,
-          input.y * scaleY,
+          (input.x - rect.x) * scaleX,
+          (input.y - rect.y) * scaleY,
           input.width * scaleX,
           input.height * scaleY
         );

--- a/SmashTools/SmashTools/Rendering/Gui/RenderTextureDrawer.cs
+++ b/SmashTools/SmashTools/Rendering/Gui/RenderTextureDrawer.cs
@@ -11,13 +11,12 @@ public static class RenderTextureDrawer
 {
   private static readonly List<RenderData> RenderDatas = [];
 
-  private static readonly int GuiClipTexId = Shader.PropertyToID("_GUIClipTexture");
-
   private static Material defaultMaterial;
 
   private static RenderTexture renderTexture;
 
-  // Fallback material for render data without one; drawn unlit/transparent via raw GL.
+  // Fallback for render data whose graphic has no RGB-mask material (e.g. non-RGB turrets, propellers);
+  // unlit + alpha-blended so soft-alpha textures composite correctly into the RT.
   private static Material DefaultMaterial => defaultMaterial ??= new Material(ShaderDatabase.MetaOverlay);
 
   public static bool InUse => renderTexture;
@@ -61,16 +60,6 @@ public static class RenderTextureDrawer
     RenderTexture prevActive = RenderTexture.active;
     RenderTexture.active = renderTexture;
 
-    // Graphics.DrawTexture honors GUI.matrix during OnGUI; neutralize it so RimWorld's UIScale
-    // doesn't compound with the GL transform below (which already fully positions each draw).
-    Matrix4x4 prevGuiMatrix = GUI.matrix;
-    GUI.matrix = Matrix4x4.identity;
-
-    // The UI shaders clip against the global _GUIClipTexture; when blitting inside a nested GUI clip
-    // (group/scroll view) that mask would crop the draw. Swap in a full-alpha mask to disable it.
-    Texture prevGuiClipTex = Shader.GetGlobalTexture(GuiClipTexId);
-    Shader.SetGlobalTexture(GuiClipTexId, Texture2D.whiteTexture);
-
     try
     {
       GL.PushMatrix();
@@ -89,11 +78,6 @@ public static class RenderTextureDrawer
       GL.Flush();
       RenderDatas.Clear();
       RenderTexture.active = prevActive;
-      GUI.matrix = prevGuiMatrix;
-      Shader.SetGlobalTexture(GuiClipTexId, prevGuiClipTex);
-      // Reset the viewport off the texture size; otherwise GL.Viewport dedupes the next blit's
-      // identical call against this value and the blit inherits a stale (e.g. icon-sized) viewport.
-      GL.Viewport(new Rect(0, 0, Screen.width, Screen.height));
     }
     return;
 

--- a/SmashTools/SmashTools/Rendering/Gui/RenderTextureDrawer.cs
+++ b/SmashTools/SmashTools/Rendering/Gui/RenderTextureDrawer.cs
@@ -11,13 +11,7 @@ public static class RenderTextureDrawer
 {
   private static readonly List<RenderData> RenderDatas = [];
 
-  private static Material defaultMaterial;
-
   private static RenderTexture renderTexture;
-
-  // Fallback for render data whose graphic has no RGB-mask material (e.g. non-RGB turrets, propellers);
-  // unlit + alpha-blended so soft-alpha textures composite correctly into the RT.
-  private static Material DefaultMaterial => defaultMaterial ??= new Material(ShaderDatabase.MetaOverlay);
 
   public static bool InUse => renderTexture;
 
@@ -83,7 +77,9 @@ public static class RenderTextureDrawer
 
     static void DrawRenderData(Rect rect, in RenderData renderData, float scale, bool center)
     {
-      Material material = renderData.material ? renderData.material : DefaultMaterial;
+      Material material = renderData.material;
+      if (!material)
+        return;
       if (renderData.mainTex)
         material.mainTexture = renderData.mainTex;
       if (!material.SetPass(0))


### PR DESCRIPTION
Fixes the rotated turret-icon misplacement in SmashPhil/Vehicle-Framework#260. Rotating a UI draw via `GUI.matrix` is mis-rendered by RimWorld/Unity at non-unit UI scale inside a GUI group — the *"vanilla bug with matrix rotations inside GUI groups"* your own `VehicleGraphics.cs` note flags. The robust fix is to draw un-rotated: compose the vehicle into an RT via `GL` (which `RenderTextureDrawer` already does correctly) and draw it flat.

`Draw` only needed to survive being called mid-`OnGUI`, which it wasn't written for:

- save/restore `RenderTexture.active` instead of asserting null (nulling it blanked the IMGUI frame);
- neutralize `GUI.matrix` (it compounds with the GL transform through `Graphics.DrawTexture`);
- white out the global `_GUIClipTexture` so a nested clip mask doesn't crop the composite;
- draw each piece with a raw `GL` quad instead of `Graphics.DrawTexture`, which re-applies the surrounding clip's viewport mid-blit and crops inside scroll views;
- reset the GL viewport afterward;
- rebase render rects to the outer rect in `NormalizeRect` (they were absolute, landing off-texture).

To be consumed by the VF-side changes — `DrawVehicleOnGUI` → new `VehicleGuiCache` → this `Draw`: https://github.com/SmashPhil/Vehicle-Framework/pull/341 (paired, bumps the submodule once this merges).